### PR TITLE
Remove source maps from build-babel script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "build": "npm run clean && npm run build-babel",
-    "build-babel": "./node_modules/.bin/babel -d ./build ./src -s",
+    "build-babel": "./node_modules/.bin/babel -d ./build ./src",
     "clean": "rm -rf build && mkdir build",
     "lint": "eslint .",
     "start": "node ./build/bin/www",


### PR DESCRIPTION
Source maps are not needed for this application